### PR TITLE
feat(renderer): add justified mixed inline text rendering and improved layout accuracy

### DIFF
--- a/examples/test-pdf-gen/src/md-text.ts
+++ b/examples/test-pdf-gen/src/md-text.ts
@@ -47,8 +47,8 @@ This section showcases how to create simple and nested lists.
 - _Italic_ text using underscores.
 - **Bold** text using double asterisks.
 - __Bold__ text using double underscores.
-- ***Bold and Italic*** text using triple asterisks.
-- ___Bold and Italic___ text using triple underscores.
+- ***Bold and Italic***  text using triple asterisks.
+- ___Bold and Italic___  text using triple underscores.
 
 ### Blockquotes
 
@@ -114,5 +114,7 @@ const generatePDF = async () => {
 
 generatePDF();
 \`\`\`
+
+This is a paragraph with **bold text** and *italic text* and \`inline code\` and a [link](https://example.com) all mixed together in a justified paragraph that should distribute spacing evenly across multiple lines.
 
 `;

--- a/examples/test-pdf-gen/src/pdfGenerator.ts
+++ b/examples/test-pdf-gen/src/pdfGenerator.ts
@@ -1,4 +1,4 @@
-import { MdTextRender, RenderOption } from "../../../dist";
+import { MdTextRender, RenderOption } from "../../../src/";
 import jsPDF from "jspdf";
 import { mdString } from "./md-text";
 
@@ -39,7 +39,7 @@ export const pdfGenerator = async () => {
     doc.rect(0, 0, width, 18, "F")
     doc.setFontSize(defaultHeadFontSize)
     doc.setTextColor(151, 166, 186)
-    doc.text("Sample Markdown Rendering Example", xpading, lineSpace*2, { align: "left" })
+    doc.text("Sample Markdown Rendering Example", xpading, lineSpace * 2, { align: "left" })
     doc.setTextColor(0, 0, 0)
     doc.setDrawColor(0, 0, 0)
     doc.setFontSize(defaultFontSize)
@@ -63,6 +63,9 @@ export const pdfGenerator = async () => {
             xmargin: xmargin,
             xpading: xpading
         },
+        content: {
+            textAlignment: "justify"
+        },
         endCursorYHandler: (endY) => { y = endY; },
         font: {
             bold: {
@@ -76,11 +79,16 @@ export const pdfGenerator = async () => {
             light: {
                 name: "",
                 style: ""
-            } 
+            }
         }
     }
     await MdTextRender(doc, mdString, options)
-    
+
+
+    // Verify End Cursor Y
+    doc.setDrawColor(255, 0, 0); // Red
+    doc.line(xpading, y, width - xpading, y);
+    doc.setDrawColor(0, 0, 0); // Reset to black
 
     const footerY = Math.min(y + 10, height - 20);
     doc.setFontSize(10);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     "homepage": "https://github.com/JeelGajera/jspdf-md-renderer#readme",
     "dependencies": {
-        "jspdf": "^3.0.4",
+        "jspdf": "^4.0.0",
         "jspdf-autotable": "^5.0.2",
         "marked": "^17.0.1"
     },
@@ -57,7 +57,7 @@
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-prettier": "^5.2.1",
-        "globals": "^16.0.0",
+        "globals": "^17.1.0",
         "prettier": "^3.4.2",
         "rimraf": "^6.0.1",
         "typescript": "^5.7.2",

--- a/src/renderer/MdTextRender.ts
+++ b/src/renderer/MdTextRender.ts
@@ -3,7 +3,6 @@ import { MdTokenType } from '../enums/mdTokenType';
 import { MdTextParser } from '../parser/MdTextParser';
 import { ParsedElement } from '../types/parsedElement';
 import { RenderOption } from '../types/renderOption';
-import { HandlePageBreaks } from '../utils/handlePageBreak';
 import {
     renderHeading,
     renderHR,
@@ -18,7 +17,6 @@ import {
     renderImage,
     renderTable,
 } from './components';
-import { getCharHight } from '../utils/doc-helpers';
 import { RenderStore } from '../store/renderStore';
 import { prefetchImages } from '../utils/image-utils';
 import { validateOptions } from '../utils/options-validation';
@@ -51,17 +49,6 @@ export const MdTextRender = async (
         justify: boolean = true,
     ) => {
         const indent = indentLevel * validOptions.page.indent;
-        if (
-            RenderStore.Y +
-                doc.splitTextToSize(
-                    element.content ?? '',
-                    validOptions.page.maxContentWidth - indent,
-                ).length *
-                    getCharHight(doc) >=
-            validOptions.page.maxContentHeight
-        ) {
-            HandlePageBreaks(doc);
-        }
 
         switch (element.type) {
             case MdTokenType.Heading:

--- a/src/renderer/components/blockquote.ts
+++ b/src/renderer/components/blockquote.ts
@@ -49,11 +49,11 @@ const renderBlockquote = (
         doc.line(barX, lineTop, barX, lineBottom);
     }
 
+    // Ensure the blockquote effectively "claims" the vertical space up to the cursor
+    RenderStore.recordContentY();
+
     // Restore page to endPage
     doc.setPage(endPage);
-
-    // Add some spacing after blockquote
-    RenderStore.updateY(options.page.lineSpace, 'add');
 };
 
 export default renderBlockquote;

--- a/src/renderer/components/heading.ts
+++ b/src/renderer/components/heading.ts
@@ -18,12 +18,13 @@ const renderHeading = (
 ) => {
     const size = 6 - (element?.depth ?? 0) > 0 ? 6 - (element?.depth ?? 0) : 1;
     doc.setFontSize(RenderStore.options.page.defaultFontSize + size);
-    RenderStore.updateY(size * 0.2 * getCharHight(doc), 'add');
+
     if (element?.items && element?.items.length > 0) {
         for (const item of element?.items ?? []) {
             parentElementRenderer(item, indent, false);
         }
     } else {
+        const charHeight = getCharHight(doc);
         doc.text(
             element?.content ?? '',
             RenderStore.X + indent,
@@ -31,13 +32,18 @@ const renderHeading = (
             {
                 align: 'left',
                 maxWidth: RenderStore.options.page.maxContentWidth - indent,
+                baseline: 'top',
             },
         );
+
+        // Record visual bottom and then advance by exactly charHeight (ultra-tight)
+        // This ensures minimal gap before the next element
+        RenderStore.recordContentY(RenderStore.Y + charHeight);
+        RenderStore.updateY(charHeight, 'add');
     }
     // Reset font size to default after heading
     doc.setFontSize(RenderStore.options.page.defaultFontSize);
-    // Move cursor to the next line after heading
-    RenderStore.updateX(RenderStore.options.page.xpading);
+    RenderStore.updateX(RenderStore.options.page.xpading, 'set');
 };
 
 export default renderHeading;

--- a/src/renderer/components/image.ts
+++ b/src/renderer/components/image.ts
@@ -62,7 +62,8 @@ const renderImage = (
             finalHeight,
         );
 
-        RenderStore.updateY(finalHeight + options.page.lineSpace, 'add');
+        RenderStore.updateY(finalHeight, 'add');
+        RenderStore.recordContentY();
     } catch (e) {
         console.warn('Failed to render image', e);
     }

--- a/src/store/renderStore.ts
+++ b/src/store/renderStore.ts
@@ -2,12 +2,14 @@ import { Cursor, RenderOption } from '../types';
 
 export class RenderStore {
     private static cursor: Cursor = { x: 0, y: 0 };
+    private static lastContentY_: number = 0;
     private static options_: RenderOption;
     private static inlineLock: boolean = false;
 
     public static initialize(options: RenderOption) {
         this.options_ = options;
         this.cursor = { x: options.cursor.x, y: options.cursor.y };
+        this.lastContentY_ = options.cursor.y;
     }
 
     public static getCursor(): Cursor {
@@ -60,6 +62,24 @@ export class RenderStore {
         } else if (operation === 'add') {
             this.cursor.y += value;
         }
+    }
+
+    /**
+     * Records a Y position as the bottom of rendered content.
+     * This is useful for container components (like blockquotes) to know
+     * where their actual text content ends, ignoring any trailing margins.
+     * @param specificY Optional Y value to record. Defaults to current cursor Y.
+     */
+    public static recordContentY(specificY?: number) {
+        this.lastContentY_ =
+            specificY !== undefined ? specificY : this.cursor.y;
+    }
+
+    /**
+     * Gets the last Y position recorded as content bottom.
+     */
+    public static get lastContentY(): number {
+        return this.lastContentY_;
     }
 
     // Convenience methods to get individual x and y values

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,4 @@
 export * from './parsedElement';
 export * from './renderOption';
+export * from './styledWordInfo';
+export * from './wordInfo';

--- a/src/types/renderOption.ts
+++ b/src/types/renderOption.ts
@@ -29,6 +29,16 @@ export type RenderOption = {
     content?: {
         textAlignment: 'left' | 'right' | 'center' | 'justify';
     };
+    codespan?: {
+        /** Background color for inline code. Default: '#EEEEEE' */
+        backgroundColor?: string;
+        /** Padding around inline code text. Default: 0.5 */
+        padding?: number;
+        /** Whether to show background rectangle. Default: true */
+        showBackground?: boolean;
+        /** Font size scale factor for code. Default: 0.9 */
+        fontSizeScale?: number;
+    };
     link?: {
         linkColor: [number, number, number];
     };

--- a/src/types/styledWordInfo.ts
+++ b/src/types/styledWordInfo.ts
@@ -1,0 +1,41 @@
+/**
+ * Enhanced word info types for styled text justification.
+ * These types allow tracking font styles per word for proper justified rendering.
+ */
+
+export type TextStyle =
+    | 'normal'
+    | 'bold'
+    | 'italic'
+    | 'bolditalic'
+    | 'codespan';
+
+/**
+ * Information about a single styled word for justified text rendering.
+ */
+export interface StyledWordInfo {
+    /** The word text */
+    text: string;
+    /** Measured width in PDF points */
+    width: number;
+    /** Font style to apply when rendering */
+    style: TextStyle;
+    /** Whether this word is part of a link */
+    isLink?: boolean;
+    /** URL if this is a link */
+    href?: string;
+    /** Optional link color override */
+    linkColor?: number[];
+}
+
+/**
+ * Represents a line of styled words for justified rendering.
+ */
+export interface StyledLine {
+    /** Words in this line */
+    words: StyledWordInfo[];
+    /** Sum of word widths (without inter-word spacing) */
+    totalTextWidth: number;
+    /** Last line of paragraph shouldn't be fully justified */
+    isLastLine: boolean;
+}

--- a/src/utils/justifiedTextRenderer.ts
+++ b/src/utils/justifiedTextRenderer.ts
@@ -1,0 +1,463 @@
+import jsPDF from 'jspdf';
+import { ParsedElement } from '../types/parsedElement';
+import { TextStyle, StyledWordInfo, StyledLine } from '../types/styledWordInfo';
+import { RenderStore } from '../store/renderStore';
+import { getCharHight } from './doc-helpers';
+import { HandlePageBreaks } from './handlePageBreak';
+
+/**
+ * JustifiedTextRenderer - Renders mixed inline elements with proper alignment.
+ *
+ * Features:
+ * - Handles bold, italic, codespan, links mixed in paragraph
+ * - Proper word spacing distribution for justified alignment
+ * - Supports left, right, center, and justify alignments
+ * - Page break handling
+ * - Preserves link clickability
+ * - Codespan background rendering
+ */
+export class JustifiedTextRenderer {
+    // Default codespan styling (can be overridden via RenderStore.options.codespan)
+    private static getCodespanOptions() {
+        const opts = RenderStore.options.codespan ?? {};
+        return {
+            backgroundColor: opts.backgroundColor ?? '#EEEEEE',
+            padding: opts.padding ?? 0.5,
+            showBackground: opts.showBackground !== false,
+            fontSizeScale: opts.fontSizeScale ?? 0.9,
+        };
+    }
+
+    /**
+     * Apply font style to the jsPDF document.
+     */
+    private static applyStyle(doc: jsPDF, style: TextStyle): void {
+        const currentFont = doc.getFont().fontName;
+        const currentFontSize = doc.getFontSize();
+
+        // Helper to get font name with fallback
+        const getBoldFont = () => {
+            const boldName = RenderStore.options.font.bold?.name;
+            return boldName && boldName !== '' ? boldName : currentFont;
+        };
+        const getRegularFont = () => {
+            const regularName = RenderStore.options.font.regular?.name;
+            return regularName && regularName !== ''
+                ? regularName
+                : currentFont;
+        };
+
+        switch (style) {
+            case 'bold':
+                doc.setFont(
+                    getBoldFont(),
+                    RenderStore.options.font.bold?.style || 'bold',
+                );
+                break;
+            case 'italic':
+                doc.setFont(getRegularFont(), 'italic');
+                break;
+            case 'bolditalic':
+                doc.setFont(getBoldFont(), 'bolditalic');
+                break;
+            case 'codespan':
+                doc.setFont('courier', 'normal');
+                doc.setFontSize(
+                    currentFontSize * this.getCodespanOptions().fontSizeScale,
+                );
+                break;
+            default:
+                doc.setFont(getRegularFont(), doc.getFont().fontStyle);
+                break;
+        }
+    }
+
+    /**
+     * Measure word width with a specific style applied.
+     * NOTE: jsPDF's getTextWidth() does NOT include charSpace in its calculation,
+     * so we must manually add it: effectiveWidth = getTextWidth(text) + (text.length * charSpace)
+     */
+    private static measureWordWidth(
+        doc: jsPDF,
+        text: string,
+        style: TextStyle,
+    ): number {
+        const savedFont = doc.getFont();
+        const savedSize = doc.getFontSize();
+
+        this.applyStyle(doc, style);
+        const baseWidth = doc.getTextWidth(text);
+
+        // Account for character spacing: jsPDF adds charSpace after EACH character
+        // For a word of N characters, rendering adds (N) * charSpace extra width
+        // But getTextWidth doesn't include this, so we add it manually
+        const charSpace = (doc as jsPDF).getCharSpace?.() ?? 0;
+        const effectiveWidth = baseWidth + text.length * charSpace;
+
+        // Restore
+        doc.setFont(savedFont.fontName, savedFont.fontStyle);
+        doc.setFontSize(savedSize);
+
+        return effectiveWidth;
+    }
+
+    /**
+     * Extract style from element type string.
+     */
+    private static getStyleFromType(
+        type: string,
+        parentStyle?: TextStyle,
+    ): TextStyle {
+        switch (type) {
+            case 'strong':
+                if (parentStyle === 'italic') return 'bolditalic';
+                return 'bold';
+            case 'em':
+                if (parentStyle === 'bold') return 'bolditalic';
+                return 'italic';
+            case 'codespan':
+                return 'codespan';
+            default:
+                return parentStyle || 'normal';
+        }
+    }
+
+    /**
+     * Flatten ParsedElement tree into an array of StyledWordInfo.
+     * Handles nested inline elements.
+     */
+    static flattenToWords(
+        doc: jsPDF,
+        elements: ParsedElement[],
+        parentStyle: TextStyle = 'normal',
+        isLink: boolean = false,
+        href?: string,
+    ): StyledWordInfo[] {
+        const result: StyledWordInfo[] = [];
+
+        for (const el of elements) {
+            const style = this.getStyleFromType(el.type, parentStyle);
+            const elIsLink = el.type === 'link' || isLink;
+            const elHref = el.href || href;
+
+            // If element has nested items, recurse
+            if (el.items && el.items.length > 0) {
+                const nested = this.flattenToWords(
+                    doc,
+                    el.items,
+                    style,
+                    elIsLink,
+                    elHref,
+                );
+                result.push(...nested);
+            } else {
+                // Leaf node: get text content
+                const text = el.content || el.text || '';
+                if (!text) continue;
+
+                // For codespan, keep the entire content as a single unit (don't split into words)
+                // This ensures the background covers all text including spaces between words
+                if (style === 'codespan') {
+                    const trimmedText = text.trim();
+                    if (trimmedText) {
+                        result.push({
+                            text: trimmedText,
+                            width: this.measureWordWidth(
+                                doc,
+                                trimmedText,
+                                style,
+                            ),
+                            style,
+                            isLink: elIsLink,
+                            href: elHref,
+                            linkColor: elIsLink
+                                ? RenderStore.options.link?.linkColor || [
+                                      0, 0, 255,
+                                  ]
+                                : undefined,
+                        });
+                    }
+                    continue;
+                }
+
+                // Split into words (preserving the knowledge of surrounding whitespace)
+                const words = text.split(/\s+/).filter((w) => w.length > 0);
+
+                // If text is ONLY whitespace, it acts as a word boundary marker
+                // We handle this by ensuring the previous and next words aren't joined
+                if (words.length === 0) {
+                    // Mark that there should be separation (handled by normal space width in rendering)
+                    continue;
+                }
+
+                for (let i = 0; i < words.length; i++) {
+                    const word = words[i];
+                    result.push({
+                        text: word,
+                        width: this.measureWordWidth(doc, word, style),
+                        style,
+                        isLink: elIsLink,
+                        href: elHref,
+                        linkColor: elIsLink
+                            ? RenderStore.options.link?.linkColor || [0, 0, 255]
+                            : undefined,
+                    });
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Break a flat list of words into lines that fit within maxWidth.
+     * Correctly tracks totalTextWidth (sum of word widths only) for justification.
+     */
+    static breakIntoLines(
+        doc: jsPDF,
+        words: StyledWordInfo[],
+        maxWidth: number,
+    ): StyledLine[] {
+        const lines: StyledLine[] = [];
+        let currentLine: StyledWordInfo[] = [];
+        let currentTextWidth = 0; // Sum of word widths only
+        let currentLineWidth = 0; // Including spaces for overflow check
+
+        // Get space width (using normal font)
+        const spaceWidth = doc.getTextWidth(' ');
+
+        for (let i = 0; i < words.length; i++) {
+            const word = words[i];
+            // For overflow check, we need to include space before word (if not first word)
+            const neededWidthWithSpace =
+                currentLine.length > 0 ? spaceWidth + word.width : word.width;
+
+            if (
+                currentLineWidth + neededWidthWithSpace > maxWidth &&
+                currentLine.length > 0
+            ) {
+                // Push current line with correct totalTextWidth (no spaces)
+                lines.push({
+                    words: currentLine,
+                    totalTextWidth: currentTextWidth,
+                    isLastLine: false,
+                });
+                // Start new line with current word
+                currentLine = [word];
+                currentTextWidth = word.width;
+                currentLineWidth = word.width;
+            } else {
+                currentLine.push(word);
+                currentTextWidth += word.width;
+                currentLineWidth += neededWidthWithSpace;
+            }
+        }
+
+        // Push last line
+        if (currentLine.length > 0) {
+            lines.push({
+                words: currentLine,
+                totalTextWidth: currentTextWidth,
+                isLastLine: true,
+            });
+        }
+
+        return lines;
+    }
+
+    /**
+     * Render a single word with its style applied.
+     */
+    private static renderWord(
+        doc: jsPDF,
+        word: StyledWordInfo,
+        x: number,
+        y: number,
+    ): void {
+        const savedFont = doc.getFont();
+        const savedSize = doc.getFontSize();
+        const savedColor = doc.getTextColor();
+
+        // Apply style
+        this.applyStyle(doc, word.style);
+
+        // Handle link color
+        if (word.isLink && word.linkColor) {
+            doc.setTextColor(...(word.linkColor as [number, number, number]));
+        }
+
+        // Draw codespan background if enabled
+        if (word.style === 'codespan') {
+            const codespanOpts = this.getCodespanOptions();
+            if (codespanOpts.showBackground) {
+                const h = getCharHight(doc);
+                const pad = codespanOpts.padding;
+                // For codespan (which is kept as a single phrase),
+                // use word.width to ensure background covers full text including charSpace
+                doc.setFillColor(codespanOpts.backgroundColor);
+                doc.rect(
+                    x - pad,
+                    y - pad,
+                    word.width + pad * 2,
+                    h + pad * 2,
+                    'F',
+                );
+                doc.setFillColor('#000000');
+            }
+        }
+
+        // Draw text
+        doc.text(word.text, x, y, { baseline: 'top' });
+
+        // Add link annotation if needed
+        if (word.isLink && word.href) {
+            const h = getCharHight(doc) / 2;
+            doc.link(x, y, word.width, h, { url: word.href });
+        }
+
+        // Restore
+        doc.setFont(savedFont.fontName, savedFont.fontStyle);
+        doc.setFontSize(savedSize);
+        doc.setTextColor(savedColor);
+    }
+
+    /**
+     * Render a single line with specified alignment.
+     */
+    static renderAlignedLine(
+        doc: jsPDF,
+        line: StyledLine,
+        x: number,
+        y: number,
+        maxWidth: number,
+        alignment: 'left' | 'right' | 'center' | 'justify' = 'left',
+    ): void {
+        const { words, totalTextWidth, isLastLine } = line;
+
+        if (words.length === 0) return;
+
+        const normalSpaceWidth = doc.getTextWidth(' ');
+
+        // Calculate starting X position based on alignment
+        let startX = x;
+        let wordSpacing = normalSpaceWidth;
+
+        const lineWidthWithNormalSpaces =
+            totalTextWidth + (words.length - 1) * normalSpaceWidth;
+
+        switch (alignment) {
+            case 'right':
+                startX = x + maxWidth - lineWidthWithNormalSpaces;
+                break;
+            case 'center':
+                startX = x + (maxWidth - lineWidthWithNormalSpaces) / 2;
+                break;
+            case 'justify':
+                if (!isLastLine && words.length > 1) {
+                    const extraSpace = maxWidth - totalTextWidth;
+                    wordSpacing = extraSpace / (words.length - 1);
+                }
+                break;
+            case 'left':
+            default:
+                // Default left alignment, use normal spacing
+                break;
+        }
+
+        // Render each word
+        let currentX = startX;
+        for (let i = 0; i < words.length; i++) {
+            this.renderWord(doc, words[i], currentX, y);
+            currentX += words[i].width;
+            if (i < words.length - 1) {
+                currentX += wordSpacing;
+            }
+        }
+    }
+
+    /**
+     * Main entry point: Render a paragraph with mixed inline elements.
+     * Respects user's textAlignment option from RenderStore.
+     *
+     * @param doc jsPDF instance
+     * @param elements Array of ParsedElement (inline items in a paragraph)
+     * @param x Starting X coordinate
+     * @param y Starting Y coordinate
+     * @param maxWidth Maximum width for text wrapping
+     * @param alignment Optional alignment override (defaults to RenderStore option)
+     */
+    static renderStyledParagraph(
+        doc: jsPDF,
+        elements: ParsedElement[],
+        x: number,
+        y: number,
+        maxWidth: number,
+        alignment?: 'left' | 'right' | 'center' | 'justify',
+    ): void {
+        // Use provided alignment or fall back to user options, default to 'left'
+        const textAlignment =
+            alignment ?? RenderStore.options.content?.textAlignment ?? 'left';
+
+        // Flatten elements to words
+        const words = this.flattenToWords(doc, elements);
+        if (words.length === 0) return;
+
+        // Break into lines
+        const lines = this.breakIntoLines(doc, words, maxWidth);
+
+        const lineHeight =
+            getCharHight(doc) *
+            RenderStore.options.page.defaultLineHeightFactor;
+
+        let currentY = y;
+
+        for (const line of lines) {
+            // Check for page break
+            if (
+                currentY + lineHeight >
+                RenderStore.options.page.maxContentHeight
+            ) {
+                HandlePageBreaks(doc);
+                currentY = RenderStore.Y;
+            }
+
+            // Render the line with proper alignment
+            this.renderAlignedLine(
+                doc,
+                line,
+                x,
+                currentY,
+                maxWidth,
+                textAlignment,
+            );
+
+            // Record the visual bottom of the text on this line
+            RenderStore.recordContentY(currentY + getCharHight(doc));
+
+            currentY += lineHeight;
+            RenderStore.updateY(lineHeight, 'add');
+        }
+
+        // Update X position to end of last line for any inline continuation
+        const lastLine = lines[lines.length - 1];
+        if (lastLine) {
+            const lastLineWidth =
+                lastLine.totalTextWidth +
+                (lastLine.words.length - 1) * doc.getTextWidth(' ');
+            RenderStore.updateX(x + lastLineWidth, 'set');
+        }
+    }
+
+    /**
+     * @deprecated Use renderStyledParagraph instead
+     */
+    static renderJustifiedParagraph(
+        doc: jsPDF,
+        elements: ParsedElement[],
+        x: number,
+        y: number,
+        maxWidth: number,
+    ): void {
+        this.renderStyledParagraph(doc, elements, x, y, maxWidth);
+    }
+}

--- a/src/utils/text-renderer.ts
+++ b/src/utils/text-renderer.ts
@@ -23,7 +23,9 @@ export class TextRenderer {
     ) {
         // Use document splitTextToSize to handle wrapping
         const lines: string[] = doc.splitTextToSize(text, maxWidth);
-        const lineHeight = getCharHight(doc);
+        const charHeight = getCharHight(doc);
+        const lineHeight =
+            charHeight * RenderStore.options.page.defaultLineHeightFactor;
 
         let currentY = y;
 
@@ -41,32 +43,21 @@ export class TextRenderer {
 
             // Render line
             if (justify) {
-                // Use justifyText utility for this line
-                // But justifyText expects a full block. We need to check if it's the last line of paragraph.
-                // splitTextToSize doesn't tell us if it's a hard break or soft break.
-                // For simplified justification:
-                // If it's the last line of the split result, default align.
-                // Else, justify.
-
                 if (i === lines.length - 1) {
-                    doc.text(line, x, currentY);
+                    doc.text(line, x, currentY, { baseline: 'top' });
                 } else {
-                    // We can't easily use existing justifyText on a single pre-split line because
-                    // justifyText splits it again.
-                    // We should likely refactor justifyText or use a simplified justification here.
-                    // For now, let's reuse justifyText but we need to be careful.
-                    // Actually, the existing renderParagraph logic tries to justify the WHOLE block.
-                    // But dealing with page breaks mid-block is hard with that approach.
-
-                    // Alternative:
                     doc.text(line, x, currentY, {
                         maxWidth: maxWidth,
                         align: 'justify',
+                        baseline: 'top',
                     });
                 }
             } else {
-                doc.text(line, x, currentY);
+                doc.text(line, x, currentY, { baseline: 'top' });
             }
+
+            // Record the visual bottom of the text on this line
+            RenderStore.recordContentY(currentY + charHeight);
 
             currentY += lineHeight;
             RenderStore.updateY(lineHeight, 'add');


### PR DESCRIPTION
- add styled justified text renderer for mixed inline elements
- support justify alignment across paragraphs and list items
- improve code block rendering, spacing, and pagination
- track actual rendered content bounds for containers
- refine heading, blockquote, image, and raw item spacing
- update example PDF generator to use justify alignment
- upgrade jsPDF to v4 and update related dependencies