### PR TITLE
chore: bump runtime and tooling dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,24 +45,24 @@
     },
     "homepage": "https://github.com/JeelGajera/jspdf-md-renderer#readme",
     "dependencies": {
-        "jspdf": "^4.0.0",
+        "jspdf": "^4.2.0",
         "jspdf-autotable": "^5.0.2",
-        "marked": "^17.0.1"
+        "marked": "^17.0.3"
     },
     "devDependencies": {
-        "@eslint/js": "^9.16.0",
-        "@types/node": "^25.0.3",
-        "@typescript-eslint/eslint-plugin": "^8.18.0",
-        "@typescript-eslint/parser": "^8.18.0",
-        "eslint": "^9.16.0",
-        "eslint-config-prettier": "^10.1.2",
-        "eslint-plugin-prettier": "^5.2.1",
-        "globals": "^17.1.0",
-        "prettier": "^3.4.2",
-        "rimraf": "^6.0.1",
-        "typescript": "^5.7.2",
-        "typescript-eslint": "^8.18.0",
-        "vite": "^7.0.4",
+        "@eslint/js": "^9.39.3",
+        "@types/node": "^25.3.0",
+        "@typescript-eslint/eslint-plugin": "^8.56.0",
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^9.39.3",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-prettier": "^5.5.5",
+        "globals": "^17.3.0",
+        "prettier": "^3.8.1",
+        "rimraf": "^6.1.3",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.56.0",
+        "vite": "^7.3.1",
         "vite-plugin-dts": "^4.5.3"
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce exposure to known dependency advisories by updating runtime libraries and bring tooling to recent compatible releases for better maintenance.

### Description
- Updated version ranges in `package.json` for runtime packages (`jspdf` -> `^4.2.0`, `marked` -> `^17.0.3`) and several dev toolchain packages (ESLint, TypeScript, Prettier, Vite, and related packages).
- Change is scoped to dependency version bumps in `package.json` only.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run build` and the production build completed successfully.
- Attempted `npm audit --json` but the advisory lookup failed with a `403 Forbidden` from the registry in this environment so a full audit could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69995ecb68d483338a2a54258e456781)