### PR TITLE
feat(image): support image sizing and alignment via markdown attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,40 @@ The following Markdown elements are currently supported by `jspdf-md-renderer`:
     ```markdown
     ![Alt text](https://example.com/image.png)
     ```
+    Images render at their **intrinsic (original) size** by default and scale down automatically if they exceed the available page width. You can control image dimensions and alignment using an optional attribute block `{...}` after the image syntax:
+
+    **Custom Attributes:**
+    | Attribute | Description | Example |
+    |-----------|-------------|---------|
+    | `width` or `w` | Image width in px | `{width=200}` or `{w=200}` |
+    | `height` or `h` | Image height in px | `{height=150}` or `{h=150}` |
+    | `align` | Alignment: `left`, `center`, `right` | `{align=center}` |
+
+    **Sizing Rules:**
+    - If only `width` is given, height is auto-calculated from aspect ratio
+    - If only `height` is given, width is auto-calculated from aspect ratio
+    - If both are given, the image uses exact dimensions (may distort if ratio differs)
+    - Images that exceed page bounds are always scaled down proportionally
+
+    **Examples:**
+    ```markdown
+    ![photo](https://example.com/photo.png)
+    ![photo](https://example.com/photo.png){width=200}
+    ![photo](https://example.com/photo.png){h=150 align=center}
+    ![photo](https://example.com/photo.png){width=200 height=150 align=right}
+    ```
+
+    **Global Default Alignment:**
+    You can set a default alignment for all images via the `image` option:
+    ```ts
+    const options = {
+        // ...other options
+        image: {
+            defaultAlign: 'center', // 'left' (default) | 'center' | 'right'
+        },
+    };
+    ```
+
 - **Inline Code**:
     ```markdown
     This is an `inline code` example.

--- a/examples/test-pdf-gen/src/md-text.ts
+++ b/examples/test-pdf-gen/src/md-text.ts
@@ -117,4 +117,30 @@ generatePDF();
 
 This is a paragraph with **bold text** and *italic text* and \`inline code\` and a [link](https://example.com) all mixed together in a justified paragraph that should distribute spacing evenly across multiple lines.
 
+### Image Rendering
+
+Images render at their original size and scale down if they exceed the page width.
+
+![Default size image](https://picsum.photos/200/300)
+
+**Image with custom width (100px):**
+
+![Width only](https://picsum.photos/200/300){width=100}
+
+**Image with custom height (50px):**
+
+![Height only](https://picsum.photos/200/300){height=50}
+
+**Image aligned center:**
+
+![Center aligned](https://picsum.photos/200/300){w=120 align=center}
+
+**Image aligned right:**
+
+![Right aligned](https://picsum.photos/200/300){w=100 align=right}
+
+**Image with both width and height:**
+
+![Both dimensions](https://picsum.photos/200/300){width=350 height=450}
+
 `;

--- a/src/parser/MdTextParser.ts
+++ b/src/parser/MdTextParser.ts
@@ -2,6 +2,10 @@
 import { TokensList, marked } from 'marked';
 import { MdTokenType } from '../enums/mdTokenType';
 import { ParsedElement } from '../types/parsedElement';
+import {
+    preprocessImageAttributes,
+    parseImageAttrsFromHref,
+} from './imageExtension';
 
 /**
  * Parses markdown into tokens and converts to a custom parsed structure.
@@ -10,7 +14,12 @@ import { ParsedElement } from '../types/parsedElement';
  * @returns Parsed markdown elements.
  */
 export const MdTextParser = async (text: string): Promise<ParsedElement[]> => {
-    const tokens = await marked.lexer(text, { async: true, gfm: true });
+    // Pre-process: encode {width=N height=N align=X} into image URL fragments
+    const processedText = preprocessImageAttributes(text);
+    const tokens = await marked.lexer(processedText, {
+        async: true,
+        gfm: true,
+    });
     // console.log(tokens);
     return convertTokens(tokens);
 };
@@ -21,7 +30,7 @@ export const MdTextParser = async (text: string): Promise<ParsedElement[]> => {
  * @param tokens - The list of markdown tokens.
  * @returns Parsed elements in a custom structure.
  */
-const convertTokens = (tokens: TokensList): ParsedElement[] => {
+const convertTokens = (tokens: TokensList | any[]): ParsedElement[] => {
     const parsedElements: ParsedElement[] = [];
     tokens.forEach((token) => {
         try {
@@ -85,11 +94,18 @@ const tokenHandlers: Record<string, (token: any) => ParsedElement> = {
             })),
         ),
     }),
-    [MdTokenType.Image]: (token) => ({
-        type: MdTokenType.Image,
-        src: token.href,
-        alt: token.text,
-    }),
+    [MdTokenType.Image]: (token) => {
+        // Decode attributes from URL fragment and get clean URL
+        const { cleanHref, attrs } = parseImageAttrsFromHref(token.href);
+        return {
+            type: MdTokenType.Image,
+            src: cleanHref,
+            alt: token.text,
+            width: attrs.width,
+            height: attrs.height,
+            align: attrs.align,
+        };
+    },
     [MdTokenType.Link]: (token) => ({
         type: MdTokenType.Link,
         href: token.href,

--- a/src/parser/imageExtension.ts
+++ b/src/parser/imageExtension.ts
@@ -1,0 +1,163 @@
+/**
+ * Internal hash prefix used to encode image attributes in the URL fragment.
+ * This is stripped during token conversion and never reaches the image fetcher.
+ */
+const ATTR_HASH_PREFIX = '__jmr_';
+
+/**
+ * Regex to match an image tag followed by an attribute block.
+ * Captures:
+ *   Group 1: Everything before the closing `)` (i.e., `![alt](url`)
+ *   Group 2: The image URL inside the parentheses
+ *   Group 3: The attribute block content (e.g., `width=200 height=150 align=center`)
+ *
+ * Pattern: ![...](url){key=value ...}
+ */
+const IMAGE_WITH_ATTRS_REGEX = /(!\[[^\]]*\]\()([^)]+)(\))\s*\{([^}]+)\}/g;
+
+/**
+ * Regex to extract individual key=value pairs from the attribute block.
+ */
+const ATTR_PAIR_REGEX = /(\w+)\s*=\s*(\w+)/g;
+
+/** Valid alignment values */
+const VALID_ALIGNMENTS = ['left', 'center', 'right'] as const;
+
+/**
+ * Parsed image attributes.
+ */
+export interface ImageAttributes {
+    width?: number;
+    height?: number;
+    align?: 'left' | 'center' | 'right';
+}
+
+/**
+ * Encodes image attributes into a URL hash fragment.
+ * Example: {width: 200, height: 100, align: 'center'} → '#__jmr_w=200&h=100&a=center'
+ */
+const encodeAttrsToFragment = (attrs: ImageAttributes): string => {
+    const parts: string[] = [];
+    if (attrs.width !== undefined) parts.push(`w=${attrs.width}`);
+    if (attrs.height !== undefined) parts.push(`h=${attrs.height}`);
+    if (attrs.align) parts.push(`a=${attrs.align}`);
+    return parts.length > 0 ? `#${ATTR_HASH_PREFIX}${parts.join('&')}` : '';
+};
+
+/**
+ * Parses an attribute string like "width=200 height=150 align=center"
+ * into a structured object.
+ */
+const parseRawAttributes = (attrString: string): ImageAttributes => {
+    const attrs: ImageAttributes = {};
+    let match;
+
+    while ((match = ATTR_PAIR_REGEX.exec(attrString)) !== null) {
+        const key = match[1].toLowerCase();
+        const value = match[2];
+
+        switch (key) {
+            case 'width':
+            case 'w': {
+                const num = parseInt(value, 10);
+                if (!isNaN(num) && num > 0) attrs.width = num;
+                break;
+            }
+            case 'height':
+            case 'h': {
+                const num = parseInt(value, 10);
+                if (!isNaN(num) && num > 0) attrs.height = num;
+                break;
+            }
+            case 'align': {
+                const alignVal = value.toLowerCase();
+                if (
+                    VALID_ALIGNMENTS.includes(
+                        alignVal as (typeof VALID_ALIGNMENTS)[number],
+                    )
+                ) {
+                    attrs.align = alignVal as ImageAttributes['align'];
+                }
+                break;
+            }
+        }
+    }
+
+    return attrs;
+};
+
+/**
+ * Pre-processes markdown text to embed image attributes into URL fragments.
+ *
+ * Transforms `![alt](url){width=200 align=center}` into
+ * `![alt](url#__jmr_w=200&a=center)` so that each image token
+ * carries its own attributes — no shared state needed.
+ *
+ * Supported attributes:
+ * - `width` or `w`: Image width in pixels (number)
+ * - `height` or `h`: Image height in pixels (number)
+ * - `align`: Image alignment - 'left', 'center', or 'right'
+ *
+ * @param text - The raw markdown text
+ * @returns The cleaned markdown text with attributes encoded in URLs
+ */
+export const preprocessImageAttributes = (text: string): string => {
+    return text.replace(
+        IMAGE_WITH_ATTRS_REGEX,
+        (_fullMatch, before, url, closeParen, attrsContent) => {
+            const attrs = parseRawAttributes(attrsContent);
+            const fragment = encodeAttrsToFragment(attrs);
+            // Reconstruct: ![alt](url#__jmr_w=200&h=100)
+            return `${before}${url}${fragment}${closeParen}`;
+        },
+    );
+};
+
+/**
+ * Extracts image attributes from a URL that may contain an encoded fragment.
+ * Returns the clean URL (without the attribute fragment) and parsed attributes.
+ *
+ * @param href - The image URL, possibly containing `#__jmr_...` fragment
+ * @returns Object with cleanHref and parsed attrs
+ */
+export const parseImageAttrsFromHref = (
+    href: string,
+): { cleanHref: string; attrs: ImageAttributes } => {
+    const fragmentIdx = href.indexOf(`#${ATTR_HASH_PREFIX}`);
+    if (fragmentIdx === -1) {
+        return { cleanHref: href, attrs: {} };
+    }
+
+    const cleanHref = href.substring(0, fragmentIdx);
+    const fragment = href.substring(fragmentIdx + 1 + ATTR_HASH_PREFIX.length);
+
+    const attrs: ImageAttributes = {};
+    const pairs = fragment.split('&');
+    for (const pair of pairs) {
+        const [key, value] = pair.split('=');
+        switch (key) {
+            case 'w': {
+                const num = parseInt(value, 10);
+                if (!isNaN(num) && num > 0) attrs.width = num;
+                break;
+            }
+            case 'h': {
+                const num = parseInt(value, 10);
+                if (!isNaN(num) && num > 0) attrs.height = num;
+                break;
+            }
+            case 'a': {
+                if (
+                    VALID_ALIGNMENTS.includes(
+                        value as (typeof VALID_ALIGNMENTS)[number],
+                    )
+                ) {
+                    attrs.align = value as ImageAttributes['align'];
+                }
+                break;
+            }
+        }
+    }
+
+    return { cleanHref, attrs };
+};

--- a/src/renderer/components/image.ts
+++ b/src/renderer/components/image.ts
@@ -1,7 +1,65 @@
 import { jsPDF } from 'jspdf';
 import { ParsedElement } from '../../types';
 import { RenderStore } from '../../store/renderStore';
+import { HandlePageBreaks } from '../../utils/handlePageBreak';
 
+/**
+ * Standard DPI for web/screen pixels.
+ */
+const DEFAULT_DPI = 96;
+
+/**
+ * Detects the image format from element data and source.
+ */
+const detectImageFormat = (element: ParsedElement): string => {
+    if (element.data) {
+        if (element.data.startsWith('data:image/png')) return 'PNG';
+        if (
+            element.data.startsWith('data:image/jpeg') ||
+            element.data.startsWith('data:image/jpg')
+        )
+            return 'JPEG';
+        if (element.data.startsWith('data:image/webp')) return 'WEBP';
+        if (element.data.startsWith('data:image/gif')) return 'GIF';
+    }
+    return element.src?.split('.').pop()?.toUpperCase() || 'JPEG';
+};
+
+/**
+ * Converts pixel values to the document's unit system.
+ * Uses 96 DPI as the standard web pixel density.
+ *
+ * @param px - Value in pixels
+ * @param unit - The document unit ('mm' | 'pt' | 'in' | 'px')
+ * @returns Value in document units
+ */
+const pxToDocUnit = (px: number, unit: string = 'mm'): number => {
+    switch (unit) {
+        case 'pt':
+            return (px * 72) / DEFAULT_DPI;
+        case 'in':
+            return px / DEFAULT_DPI;
+        case 'px':
+            return px;
+        case 'mm':
+        default:
+            return (px * 25.4) / DEFAULT_DPI;
+    }
+};
+
+/**
+ * Renders an image element into the jsPDF document with smart sizing and alignment.
+ *
+ * Sizing logic (in order of priority):
+ * 1. If both width & height are specified by user → convert from px, use as-is
+ * 2. If only width is specified → convert from px, calculate height from aspect ratio
+ * 3. If only height is specified → convert from px, calculate width from aspect ratio
+ * 4. If nothing specified → use intrinsic dimensions (converted from px to doc units)
+ * 5. Always clamp to page bounds (scale down proportionally if needed)
+ *
+ * Alignment: 'left' (default) | 'center' | 'right'
+ * Can be set per-image via markdown attributes or globally via RenderOption.image.defaultAlign
+ */
 const renderImage = (
     doc: jsPDF,
     element: ParsedElement,
@@ -12,51 +70,88 @@ const renderImage = (
     }
 
     const options = RenderStore.options;
-    const currentX = RenderStore.X + indentLevel * options.page.indent;
+    const docUnit = options.page.unit || 'mm';
+    const indent = indentLevel * options.page.indent;
+    const maxWidth = options.page.maxContentWidth - indent;
+    const pageLeftX = RenderStore.X + indent;
     let currentY = RenderStore.Y;
 
-    // Check available width
-    const maxWidth =
-        options.page.maxContentWidth - indentLevel * options.page.indent;
-
     try {
+        // Get intrinsic image dimensions (always in pixels)
         const props = doc.getImageProperties(element.data);
-        const imgWidth = props.width;
-        const imgHeight = props.height;
+        const intrinsicPxW = props.width;
+        const intrinsicPxH = props.height;
+        const aspectRatio = intrinsicPxH > 0 ? intrinsicPxW / intrinsicPxH : 1;
 
-        // Calculate scaled dimensions to fit maxWidth
-        let finalWidth = imgWidth;
-        let finalHeight = imgHeight;
+        // --- Determine final dimensions (in document units) ---
+        let finalWidth: number;
+        let finalHeight: number;
 
-        const aspectRatio = imgWidth / imgHeight;
-
-        // We can restrict max width to the page content width
-        if (finalWidth > 0) {
-            finalWidth = maxWidth;
+        if (element.width && element.height) {
+            // Both specified (in px): convert to doc units
+            finalWidth = pxToDocUnit(element.width, docUnit);
+            finalHeight = pxToDocUnit(element.height, docUnit);
+        } else if (element.width) {
+            // Width only (in px): convert and calculate height from aspect ratio
+            finalWidth = pxToDocUnit(element.width, docUnit);
             finalHeight = finalWidth / aspectRatio;
+        } else if (element.height) {
+            // Height only (in px): convert and calculate width from aspect ratio
+            finalHeight = pxToDocUnit(element.height, docUnit);
+            finalWidth = finalHeight * aspectRatio;
+        } else {
+            // No dimensions specified: convert intrinsic px to doc units
+            finalWidth = pxToDocUnit(intrinsicPxW, docUnit);
+            finalHeight = pxToDocUnit(intrinsicPxH, docUnit);
         }
 
-        // Check for page break
+        // --- Clamp to page bounds ---
+        // If image exceeds available width, scale down proportionally
+        if (finalWidth > maxWidth) {
+            const scale = maxWidth / finalWidth;
+            finalWidth = maxWidth;
+            finalHeight = finalHeight * scale;
+        }
+
+        // If image exceeds available content height, scale down proportionally
+        const maxH = options.page.maxContentHeight - options.page.topmargin;
+        if (finalHeight > maxH) {
+            const scale = maxH / finalHeight;
+            finalHeight = maxH;
+            finalWidth = finalWidth * scale;
+        }
+
+        // --- Page break check ---
         if (currentY + finalHeight > options.page.maxContentHeight) {
-            doc.addPage();
-            currentY = options.page.topmargin;
-            RenderStore.updateY(currentY);
+            HandlePageBreaks(doc);
+            currentY = RenderStore.Y;
         }
 
-        // Detect format from data URI or extension
-        let imgFormat = element.src?.split('.').pop()?.toUpperCase() || 'JPEG';
-        if (element.data.startsWith('data:image/png')) imgFormat = 'PNG';
-        else if (
-            element.data.startsWith('data:image/jpeg') ||
-            element.data.startsWith('data:image/jpg')
-        )
-            imgFormat = 'JPEG';
-        else if (element.data.startsWith('data:image/webp')) imgFormat = 'WEBP';
+        // --- Alignment ---
+        const align = element.align || options.image?.defaultAlign || 'left';
 
+        let drawX: number;
+        switch (align) {
+            case 'right':
+                drawX = pageLeftX + maxWidth - finalWidth;
+                break;
+            case 'center':
+                drawX = pageLeftX + (maxWidth - finalWidth) / 2;
+                break;
+            case 'left':
+            default:
+                drawX = pageLeftX;
+                break;
+        }
+
+        // --- Detect format ---
+        const imgFormat = detectImageFormat(element);
+
+        // --- Draw ---
         doc.addImage(
             element.data,
             imgFormat,
-            currentX,
+            drawX,
             currentY,
             finalWidth,
             finalHeight,

--- a/src/types/parsedElement.ts
+++ b/src/types/parsedElement.ts
@@ -14,4 +14,12 @@ export type ParsedElement = {
     header?: ParsedElement[];
     rows?: ParsedElement[][];
     data?: string;
+    // Image sizing attributes (in document units, e.g. mm for A4)
+    width?: number;
+    height?: number;
+    // Image alignment: 'left' | 'center' | 'right'
+    align?: 'left' | 'center' | 'right';
+    // Intrinsic image dimensions (set during prefetch via getImageProperties)
+    naturalWidth?: number;
+    naturalHeight?: number;
 };

--- a/src/types/renderOption.ts
+++ b/src/types/renderOption.ts
@@ -43,6 +43,10 @@ export type RenderOption = {
         linkColor: [number, number, number];
     };
     table?: UserOptions;
+    image?: {
+        /** Default alignment for images: 'left' | 'center' | 'right'. Default: 'left' */
+        defaultAlign?: 'left' | 'center' | 'right';
+    };
     pageBreakHandler?: (doc: jsPDF) => void;
     endCursorYHandler: (y: number) => void;
 };

--- a/src/utils/options-validation.ts
+++ b/src/utils/options-validation.ts
@@ -20,6 +20,9 @@ const defaultOptions: Partial<RenderOption> = {
         regular: { name: 'helvetica', style: 'normal' },
         light: { name: 'helvetica', style: 'light' },
     },
+    image: {
+        defaultAlign: 'left',
+    },
 };
 
 export const validateOptions = (options: RenderOption): RenderOption => {
@@ -30,6 +33,7 @@ export const validateOptions = (options: RenderOption): RenderOption => {
     // Merge defaults
     const mergedPage = { ...defaultOptions.page, ...options.page };
     const mergedFont = { ...defaultOptions.font, ...options.font };
+    const mergedImage = { ...defaultOptions.image, ...options.image };
 
     // Ensure critical defaults if missing
     if (!mergedPage.maxContentWidth) mergedPage.maxContentWidth = 190;
@@ -39,5 +43,6 @@ export const validateOptions = (options: RenderOption): RenderOption => {
         ...options,
         page: mergedPage,
         font: mergedFont,
+        image: mergedImage,
     } as RenderOption;
 };


### PR DESCRIPTION
### ✨ New Features
- Added support for image attributes `{width|w}`, `{height|h}`, and `{align}` in Markdown
- Images now render at intrinsic size by default and scale down to fit page bounds
- Introduced global image alignment option via `image.defaultAlign`

### 🧠 Parsing & Processing
- Implemented image attribute preprocessing by encoding attributes into URL fragments
- Added decoding logic to extract image attributes during token conversion
- Extended parsed image elements to include width, height, and alignment metadata

### 🖼 Rendering Improvements
- Added smart image sizing logic with aspect-ratio preservation
- Implemented pixel → document unit conversion (96 DPI standard)
- Added left, center, and right alignment support during rendering
- Ensured images scale proportionally when exceeding page width or height
- Integrated proper page break handling for oversized images
- Improved image format detection (PNG, JPEG, WEBP, GIF)

### 🧩 Configuration & Types
- Extended `RenderOption` to include image defaults
- Updated option validation to merge image defaults safely
- Enhanced image-related type definitions

fixes #44 
