### PR TITLE
Inline-image-seems-rendered-at-wrong-position

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
         "pdf",
         "renderer"
     ],
-    "author": "Jeel Gajera <jeelgajera200@gmail.com>",
+    "author": {
+        "name": "Jeel Gajera",
+        "url": "https://github.com/JeelGajera"
+    },
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/JeelGajera/jspdf-md-renderer/issues"

--- a/src/renderer/MdTextRender.ts
+++ b/src/renderer/MdTextRender.ts
@@ -45,8 +45,6 @@ export const MdTextRender = async (
         hasRawBullet: boolean = false,
         start: number = 0,
         ordered: boolean = false,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        justify: boolean = true,
     ) => {
         const indent = indentLevel * validOptions.page.indent;
 
@@ -74,7 +72,7 @@ export const MdTextRender = async (
                 renderHR(doc);
                 break;
             case MdTokenType.Code:
-                renderCodeBlock(doc, element, indentLevel, hasRawBullet);
+                renderCodeBlock(doc, element, indentLevel);
                 break;
             case MdTokenType.Strong:
             case MdTokenType.Em:
@@ -103,7 +101,7 @@ export const MdTextRender = async (
                     renderElement,
                     start,
                     ordered,
-                    validOptions.page.defaultFontSize > 0, // Using validOptions here if needed, or just true for justify
+                    validOptions.content?.textAlignment === 'justify',
                 );
                 break;
             default:

--- a/src/renderer/components/code.ts
+++ b/src/renderer/components/code.ts
@@ -7,8 +7,6 @@ const renderCodeBlock = (
     doc: jsPDF,
     element: ParsedElement,
     indentLevel: number,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    hasRawBullet: boolean,
 ) => {
     // Save current font state
     const savedFont = doc.getFont();

--- a/src/utils/justifiedTextRenderer.ts
+++ b/src/utils/justifiedTextRenderer.ts
@@ -354,7 +354,9 @@ export class JustifiedTextRenderer {
 
                 if (word.width > 0 && (word.imageHeight || 0) > 0) {
                     const imgH = word.imageHeight || 0;
-                    const imgY = y - imgH;
+                    // Draw image at the same Y as text (top-aligned),
+                    // since text uses baseline: 'top'
+                    const imgY = y;
 
                     doc.addImage(
                         word.imageElement.data,
@@ -471,8 +473,12 @@ export class JustifiedTextRenderer {
                     ? word.imageHeight
                     : textHeight;
 
-            // Align to bottom (baseline) of the tallest element in the line
-            if (elementHeight < line.lineHeight) {
+            if (word.isImage) {
+                // Images: top-align within the line
+                drawY = y;
+            } else if (elementHeight < line.lineHeight) {
+                // Text: bottom-align so text baseline sits at the bottom
+                // of the tallest element (the image)
                 drawY = y + (line.lineHeight - elementHeight);
             }
 


### PR DESCRIPTION
chore(rendering): clean-up unused parameters, improve image and text alignment in justified text.

fixes #51 