### PR TITLE
fix(renderer): support newline-aware justified headings and styled rendering

### DIFF
--- a/src/renderer/components/heading.ts
+++ b/src/renderer/components/heading.ts
@@ -2,6 +2,7 @@ import jsPDF from 'jspdf';
 import { ParsedElement } from '../../types/parsedElement';
 import { RenderStore } from '../../store/renderStore';
 import { getCharHight } from '../../utils/doc-helpers';
+import { JustifiedTextRenderer } from '../../utils/justifiedTextRenderer';
 
 /**
  * Renders heading elements.
@@ -22,9 +23,24 @@ const renderHeading = (
     doc.setFontSize(store.options.page.defaultFontSize + size);
 
     if (element?.items && element?.items.length > 0) {
-        for (const item of element?.items ?? []) {
-            parentElementRenderer(item, indent, store, false);
-        }
+        // Use JustifiedTextRenderer to render mixed styled items correctly
+        // We temporarily override the defaultLineHeightFactor to 1.0 to match the 
+        // ultra-tight spacing of unstyled headings.
+        const originalLineHeightFactor = store.options.page.defaultLineHeightFactor;
+        store.options.page.defaultLineHeightFactor = 1.0;
+
+        JustifiedTextRenderer.renderStyledParagraph(
+            doc,
+            element.items,
+            store.X + indent,
+            store.Y,
+            store.options.page.maxContentWidth - indent,
+            store,
+            'left'
+        );
+
+        // Restore original line height factor
+        store.options.page.defaultLineHeightFactor = originalLineHeightFactor;
     } else {
         const charHeight = getCharHight(doc);
         doc.text(element?.content ?? '', store.X + indent, store.Y, {

--- a/src/utils/justifiedTextRenderer.ts
+++ b/src/utils/justifiedTextRenderer.ts
@@ -230,34 +230,50 @@ export class JustifiedTextRenderer {
                     continue;
                 }
 
-                // Split into words, ignoring spaces
-                const words = text
-                    .trim()
-                    .split(/\s+/)
-                    .filter((w) => w.length > 0);
+                // Split into words, honoring newlines as hard breaks
+                const lines = text.split('\n');
+                
+                for (let partIndex = 0; partIndex < lines.length; partIndex++) {
+                    const lineStr = lines[partIndex];
+                    
+                    const words = lineStr
+                        .trim()
+                        .split(/[ \t\r\v\f]+/)
+                        .filter((w) => w.length > 0);
 
-                for (let i = 0; i < words.length; i++) {
-                    const isLastWord = i === words.length - 1;
-                    // The word has a trailing space if it's NOT the last word in the string,
-                    // OR if it IS the last word, but the original string ended with a space.
-                    const hasTrailingSpace = !isLastWord || /\s$/.test(text);
+                    for (let i = 0; i < words.length; i++) {
+                        const isLastWord = i === words.length - 1;
+                        // The word has a trailing space if it's NOT the last word in the string,
+                        // OR if it IS the last word, but the original line string ended with a space.
+                        const hasTrailingSpace = !isLastWord || /[ \t\r\v\f]$/.test(lineStr);
 
-                    result.push({
-                        text: words[i],
-                        width: this.measureWordWidth(
-                            doc,
-                            words[i],
+                        result.push({
+                            text: words[i],
+                            width: this.measureWordWidth(
+                                doc,
+                                words[i],
+                                style,
+                                store,
+                            ),
                             style,
-                            store,
-                        ),
-                        style,
-                        isLink: elIsLink,
-                        href: elHref,
-                        linkColor: elIsLink
-                            ? store.options.link?.linkColor || [0, 0, 255]
-                            : undefined,
-                        hasTrailingSpace: hasTrailingSpace,
-                    });
+                            isLink: elIsLink,
+                            href: elHref,
+                            linkColor: elIsLink
+                                ? store.options.link?.linkColor || [0, 0, 255]
+                                : undefined,
+                            hasTrailingSpace: hasTrailingSpace,
+                        });
+                    }
+                    
+                    // If not the last line, insert a break
+                    if (partIndex < lines.length - 1) {
+                        result.push({
+                            text: '',
+                            width: 0,
+                            style,
+                            isBr: true,
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
- use `JustifiedTextRenderer` for heading items to correctly render mixed styles
- temporarily set `defaultLineHeightFactor` to `1.0` for tighter heading spacing
- restore original line height after rendering
- enhance text splitting to respect newline characters as hard line breaks
- improve word parsing to handle varied whitespace characters
- add explicit line break tokens (`isBr`) for multi-line rendering
- fix trailing space detection per line instead of entire text
- fixes #63 