### PR TITLE
fix(security): harden URL validation and markdown parser against SSRF and DoS

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ Behavior notes:
 
 Security is disabled by default for backward compatibility.
 
+> **Always-on baseline limits (cannot be disabled):**
+> Regardless of the `security.enabled` setting, `MdTextParser` (and by extension
+> `MdTextRender`) enforces two unconditional hard limits to prevent the underlying
+> Markdown parser from crashing the host process:
+>
+> - **Absolute length ceiling:** Inputs larger than **2 MB** (2,000,000 characters) are
+>   rejected with a `MarkdownParsingLimitError` before parsing begins.
+> - **Structural nesting ceiling:** Blockquote or list structures nested more than
+>   **300 levels** deep are rejected with a `MarkdownParsingLimitError`.
+>
+> These limits exist because deeply nested or oversized Markdown can cause stack
+> exhaustion or memory exhaustion in the parser regardless of any security settings.
+> `MarkdownParsingLimitError` is exported from `jspdf-md-renderer` and can be caught
+> and handled by callers.
+
 ```ts
 const options = {
   // ...other options
@@ -233,6 +248,7 @@ Browser caveat:
 - `MdTextRender`
 - `MdTextParser`
 - `SecurityViolationError`
+- `MarkdownParsingLimitError`
 - `validateOptions`
 - Types: `RenderOption`, `RenderSecurityOptions`, `SecurityViolation`, `ViolationMode`, and others
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { renderInlineContent, renderPlainText } from './layout';
 export type { RenderOption } from './types/renderOption';
 export type { ParsedElement } from './types/parsedElement';
 export { SecurityViolationError } from './types/security';
+export { MarkdownParsingLimitError } from './security/pre-parse-guards';
 export type {
     RenderSecurityOptions,
     SecurityViolation,

--- a/src/parser/MdTextParser.ts
+++ b/src/parser/MdTextParser.ts
@@ -6,6 +6,11 @@ import {
     preprocessImageAttributes,
     parseImageAttrsFromHref,
 } from './imageExtension';
+import {
+    enforceAbsoluteMarkdownLengthLimit,
+    enforceStructuralSafetyLimits,
+    MarkdownParsingLimitError,
+} from '../security/pre-parse-guards';
 
 /**
  * Parses markdown into tokens and converts to a custom parsed structure.
@@ -14,12 +19,32 @@ import {
  * @returns Parsed markdown elements.
  */
 export const MdTextParser = async (text: string): Promise<ParsedElement[]> => {
+    // Hard, unconditional safety limits — always run, regardless of the
+    // opt-in `security` option. See src/security/pre-parse-guards.ts.
+    enforceAbsoluteMarkdownLengthLimit(text);
+    enforceStructuralSafetyLimits(text);
+
     // Pre-process: encode {width=N height=N align=X} into image URL fragments
     const processedText = preprocessImageAttributes(text);
-    const tokens = await marked.lexer(processedText, {
-        async: true,
-        gfm: true,
-    });
+
+    let tokens: TokensList;
+    try {
+        tokens = await marked.lexer(processedText, {
+            async: true,
+            gfm: true,
+        });
+    } catch (error) {
+        // Convert an uncaught parser crash (e.g. stack overflow on
+        // pathological input that slipped past the structural heuristic
+        // above) into a typed, catchable error instead of letting it
+        // propagate as a raw RangeError/unhandled rejection.
+        throw new MarkdownParsingLimitError(
+            `[jspdf-md-renderer] Markdown parsing failed, likely due to excessive ` +
+            `structural complexity in the input. Original error: ${error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
+
     return convertTokens(tokens);
 };
 

--- a/src/security/pre-parse-guards.ts
+++ b/src/security/pre-parse-guards.ts
@@ -1,0 +1,126 @@
+/**
+ * Hard, unconditional safety limits applied to every Markdown input before
+ * it reaches the underlying parser. These are NOT part of the opt-in
+ * `security` option and cannot be disabled — they exist purely to prevent
+ * the parser itself (a third-party dependency) from being driven into
+ * stack-overflow or memory-exhaustion crashes, regardless of whether the
+ * integrator has configured `security.enabled`.
+ */
+
+export class MarkdownParsingLimitError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'MarkdownParsingLimitError';
+    }
+}
+
+/** Absolute ceiling on input size, enforced regardless of `security.enabled`. */
+const ABSOLUTE_MAX_MARKDOWN_LENGTH = 2_000_000; // 2 MB
+
+/**
+ * Generous ceiling on structural nesting depth. Real-world documents rarely
+ * nest blockquotes or lists more than 10–20 levels deep; 300 leaves ample
+ * headroom while sitting far below the depths (~3,500 for blockquotes,
+ * ~1,200 for list chains) needed to crash the underlying parser.
+ */
+const MAX_SAFE_STRUCTURAL_DEPTH = 300;
+
+/** Matches a Markdown list item marker with its leading indentation. */
+const LIST_ITEM_RE = /^([ \t]*)([-*+]|\d+[.)])\s/;
+
+/**
+ * Scans for the deepest run of `>` blockquote markers found at the start of
+ * any single line. O(n) single pass, no recursion.
+ */
+const estimateMaxBlockquoteDepth = (text: string): number => {
+    let maxDepth = 0;
+    let i = 0;
+    const len = text.length;
+    while (i < len) {
+        let lineEnd = text.indexOf('\n', i);
+        if (lineEnd === -1) lineEnd = len;
+
+        let j = i;
+        let leadingSpaces = 0;
+        while (j < lineEnd && text[j] === ' ' && leadingSpaces < 3) {
+            j++;
+            leadingSpaces++;
+        }
+
+        let depth = 0;
+        while (j < lineEnd && text[j] === '>') {
+            depth++;
+            j++;
+            if (text[j] === ' ') j++;
+        }
+
+        if (depth > maxDepth) maxDepth = depth;
+        i = lineEnd + 1;
+    }
+    return maxDepth;
+};
+
+/**
+ * Scans for the longest run of consecutive list-item lines whose indentation
+ * strictly increases from one line to the next — the exact shape that
+ * causes the underlying parser's memory blow-up. O(n) single pass.
+ */
+const estimateMaxListChainDepth = (text: string): number => {
+    const lines = text.split('\n');
+    let maxChain = 0;
+    let chainLen = 0;
+    let prevIndent = -1;
+
+    for (const line of lines) {
+        const match = LIST_ITEM_RE.exec(line);
+        if (!match) {
+            chainLen = 0;
+            prevIndent = -1;
+            continue;
+        }
+        const indent = match[1].length;
+        chainLen = indent > prevIndent ? chainLen + 1 : 1;
+        prevIndent = indent;
+        if (chainLen > maxChain) maxChain = chainLen;
+    }
+    return maxChain;
+};
+
+/**
+ * Throws if `text` exceeds the absolute hard length ceiling. Always runs,
+ * regardless of the `security` option.
+ */
+export const enforceAbsoluteMarkdownLengthLimit = (text: string): void => {
+    if (text.length > ABSOLUTE_MAX_MARKDOWN_LENGTH) {
+        throw new MarkdownParsingLimitError(
+            `[jspdf-md-renderer] Markdown input length (${text.length}) exceeds the ` +
+            `absolute hard limit (${ABSOLUTE_MAX_MARKDOWN_LENGTH} characters). This limit ` +
+            `is enforced unconditionally and cannot be disabled via the 'security' option.`,
+        );
+    }
+};
+
+/**
+ * Throws if `text` contains blockquote or list nesting deep enough to risk
+ * crashing the underlying parser. Always runs, regardless of the `security`
+ * option.
+ */
+export const enforceStructuralSafetyLimits = (text: string): void => {
+    const bqDepth = estimateMaxBlockquoteDepth(text);
+    if (bqDepth > MAX_SAFE_STRUCTURAL_DEPTH) {
+        throw new MarkdownParsingLimitError(
+            `[jspdf-md-renderer] Blockquote nesting depth (${bqDepth}) exceeds the hard ` +
+            `safety limit (${MAX_SAFE_STRUCTURAL_DEPTH}). This limit is enforced ` +
+            `unconditionally to prevent parser stack exhaustion and cannot be disabled.`,
+        );
+    }
+
+    const listChainDepth = estimateMaxListChainDepth(text);
+    if (listChainDepth > MAX_SAFE_STRUCTURAL_DEPTH) {
+        throw new MarkdownParsingLimitError(
+            `[jspdf-md-renderer] List nesting chain depth (${listChainDepth}) exceeds the ` +
+            `hard safety limit (${MAX_SAFE_STRUCTURAL_DEPTH}). This limit is enforced ` +
+            `unconditionally to prevent parser memory exhaustion and cannot be disabled.`,
+        );
+    }
+};

--- a/src/security/security-policy.ts
+++ b/src/security/security-policy.ts
@@ -357,9 +357,27 @@ const isAllowedDomain = (
 
 type UrlClass = 'explicitScheme' | 'protocolRelative' | 'relativePath';
 
+/**
+ * Mirrors the WHATWG URL parser's own preprocessing before we make any
+ * security decision based on the shape of the string. Two things browsers
+ * (and Node's URL/fetch implementation) do that we must match:
+ *
+ * 1. Strip ASCII tab / newline / CR before parsing.
+ * 2. For special schemes (http/https/ws/wss/ftp/file), treat backslashes
+ *    the same as forward slashes when resolving a reference.
+ *
+ * Without this, a string like "\\evil.com/x" is classified as a harmless
+ * "relative path" (and thus allowed with zero protocol/domain/SSRF checks),
+ * even though it actually resolves to https://evil.com/x once any real URL
+ * parser (browser, fetch, PDF viewer) gets hold of it.
+ */
+const normalizeUrlForClassification = (raw: string): string =>
+    raw.replace(/[\t\n\r]/g, '').replace(/\\/g, '/');
+
 const classifyUrl = (raw: string): UrlClass => {
-    if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(raw)) return 'explicitScheme';
-    if (raw.startsWith('//')) return 'protocolRelative';
+    const normalized = normalizeUrlForClassification(raw);
+    if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(normalized)) return 'explicitScheme';
+    if (normalized.startsWith('//')) return 'protocolRelative';
     return 'relativePath';
 };
 
@@ -377,15 +395,17 @@ export const validateResourceUrl = async (
     security: RenderSecurityOptions,
     context?: string,
 ): Promise<boolean> => {
-    // Protocol-relative URLs (//host/path) are intentionally treated as
-    // external absolute URLs for security checks.
+    // Classify (and construct any URL object) using the normalized form —
+    // never the raw attacker string — so classification and resolution can
+    // never disagree with each other.
+    const normalizedValue = normalizeUrlForClassification(rawValue);
     const urlClass = classifyUrl(rawValue);
 
     if (urlClass === 'relativePath') {
         if (security.validateUrl) {
             let relativeUrl: URL;
             try {
-                relativeUrl = new URL(rawValue, 'https://relative.local');
+                relativeUrl = new URL(normalizedValue, 'https://relative.local');
             } catch {
                 handleSecurityViolation(
                     security,
@@ -417,9 +437,9 @@ export const validateResourceUrl = async (
         return true;
     }
 
-    let canonicalRaw = rawValue;
+    let canonicalRaw = normalizedValue;
     if (urlClass === 'protocolRelative') {
-        canonicalRaw = `https:${rawValue}`;
+        canonicalRaw = `https:${normalizedValue}`;
     }
 
     let parsed: URL;
@@ -444,9 +464,9 @@ export const validateResourceUrl = async (
         const protocolList =
             type === 'link'
                 ? security.allowedLinkProtocols ||
-                  DEFAULT_SECURITY.allowedLinkProtocols
+                DEFAULT_SECURITY.allowedLinkProtocols
                 : security.allowedImageProtocols ||
-                  DEFAULT_SECURITY.allowedImageProtocols;
+                DEFAULT_SECURITY.allowedImageProtocols;
 
         if (!protocolList.includes(protocol)) {
             handleSecurityViolation(
@@ -518,9 +538,9 @@ export const validateResourceUrl = async (
         if (type === 'image') {
             console.warn(
                 '[jspdf-md-renderer] Security warning: IP-based SSRF checks ' +
-                    '(blockPrivateIPs, blockLinkLocalIPs, blockMetadataIPs) ' +
-                    'cannot be fully enforced in browser environments. Route image ' +
-                    'fetching through a trusted server-side proxy.',
+                '(blockPrivateIPs, blockLinkLocalIPs, blockMetadataIPs) ' +
+                'cannot be fully enforced in browser environments. Route image ' +
+                'fetching through a trusted server-side proxy.',
             );
         }
     } else {

--- a/test/helpers/mockDoc.ts
+++ b/test/helpers/mockDoc.ts
@@ -57,6 +57,7 @@ export class MockDoc {
             getCurrentPageInfo: () => ({
                 pageNumber: this.currentPage,
             }),
+            getNumberOfPages: () => this.currentPage,
         };
     }
 

--- a/test/parser/dos-nested-structures.test.ts
+++ b/test/parser/dos-nested-structures.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { MdTextParser } from '../../src/parser/MdTextParser';
+import { MarkdownParsingLimitError } from '../../src/security/pre-parse-guards';
+
+describe('Parser resource-exhaustion hardening', () => {
+    it('rejects deeply nested blockquotes before they can crash the parser', async () => {
+        const md = '> '.repeat(5000) + 'text'; // previously caused an uncaught RangeError
+        await expect(MdTextParser(md)).rejects.toThrow(MarkdownParsingLimitError);
+    });
+
+    it('rejects deeply chained nested lists before they can exhaust memory', async () => {
+        let md = '';
+        for (let i = 0; i < 1500; i++) md += ' '.repeat(i * 2) + '- item\n';
+        await expect(MdTextParser(md)).rejects.toThrow(MarkdownParsingLimitError);
+    }, 15000); // generous timeout: this must fail FAST via the pre-parse heuristic,
+    // but give CI some headroom in case the heuristic itself is slow
+
+    it('rejects input above the absolute hard length ceiling regardless of security option', async () => {
+        const md = 'a'.repeat(2_000_001);
+        await expect(MdTextParser(md)).rejects.toThrow(MarkdownParsingLimitError);
+    });
+
+    it('still parses a realistic, modestly nested blockquote (no false positive)', async () => {
+        const md = '> '.repeat(20) + 'a normal deeply quoted comment';
+        await expect(MdTextParser(md)).resolves.toBeDefined();
+    });
+
+    it('still parses a realistic, modestly nested list (no false positive)', async () => {
+        let md = '';
+        for (let i = 0; i < 15; i++) md += ' '.repeat(i * 2) + `- item ${i}\n`;
+        await expect(MdTextParser(md)).resolves.toBeDefined();
+    });
+
+    it('the pre-parse structural scan itself stays fast on large legitimate input', async () => {
+        const md = Array.from(
+            { length: 5000 },
+            (_, i) => `Paragraph number ${i} with some normal prose text.`,
+        ).join('\n\n');
+        const start = Date.now();
+        await MdTextParser(md);
+        expect(Date.now() - start).toBeLessThan(1000);
+    });
+});

--- a/test/renderer/security-ssrf-bypass.test.ts
+++ b/test/renderer/security-ssrf-bypass.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MdTextRender } from '../../src/renderer/MdTextRender';
+import { createRenderOptions } from '../helpers/renderOptions';
+import { MockDoc } from '../helpers/mockDoc';
+import { prefetchImages } from '../../src/utils/image-utils';
+import { createSecurity } from '../helpers/security';
+
+describe('MdTextRender SSRF bypass regression (end-to-end)', () => {
+    beforeEach(() => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(() =>
+                Promise.reject(new Error('fetch should not be called for a blocked host')),
+            ),
+        );
+    });
+    afterEach(() => vi.unstubAllGlobals());
+
+    /**
+     * REAL ATTACK PATH — full Markdown → marked.lexer → security → prefetch pipeline.
+     *
+     * The exploit uses angle-bracket URL syntax in Markdown to prevent marked from
+     * stripping backslashes. `marked` then preserves the backslash characters in
+     * the href token value.
+     *
+     *   Markdown text:   ![t](<\\evil.example.com/tracker.png>)
+     *   marked href:     \\evil.example.com/tracker.png  (double backslash preserved)
+     *
+     * BEFORE the fix:
+     *   classifyUrl("\\evil.example.com/...") → 'relativePath'
+     *   (backslash prefix matched neither "//" nor an explicit scheme)
+     *   → all domain/SSRF checks bypassed → fetch() called with the raw value
+     *
+     * AFTER the fix:
+     *   normalizeUrlForClassification replaces every \ with / first:
+     *   "\\evil.example.com/..." → "//evil.example.com/..." → 'protocolRelative'
+     *   → domain check: evil.example.com ∉ allowedImageDomains → blocked
+     *   → fetch() never called
+     *
+     * JS string escaping note (4 backslashes in JS source = 2 in string value):
+     *   '\\\\evil.example.com' in JS source = \\evil.example.com in the string
+     *   Inside the angle-bracket Markdown url <\\evil.example.com>, marked preserves
+     *   the two backslashes verbatim in the href token.
+     */
+    it('blocks a double-backslash obfuscated image host through the full markdown render path', async () => {
+        const doc = new MockDoc();
+        // Markdown angle-bracket syntax preserves backslashes in the href token.
+        // This string has 8 backslash chars in JS source = 4 literal backslashes at
+        // runtime = the markdown text contains <\\\\evil.example.com/...>.
+        // marked parses that and emits href: "\\evil.example.com/..." (2 backslashes).
+        // normalizeUrlForClassification maps each \ → /, giving "//evil.example.com/..."
+        // which is classified protocolRelative and blocked by allowedImageDomains.
+        const md = '![tracker](<\\\\\\\\evil.example.com/tracker.png>)';
+        await MdTextRender(
+            doc as never,
+            md,
+            createRenderOptions({
+                security: {
+                    enabled: true,
+                    allowedImageDomains: ['good.example.com'],
+                    blockPrivateIPs: true,
+                    blockMetadataIPs: true,
+                    violationMode: 'skip',
+                },
+            }),
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('blocks a slash-backslash obfuscated image host through the full markdown render path', async () => {
+        const doc = new MockDoc();
+        // Markdown angle-bracket form </\evil.example.com/...>:
+        // marked emits href: "/\evil.example.com/..." (slash + single backslash)
+        // normalizeUrlForClassification: / stays, \ → / → "//evil.example.com/..." → protocolRelative → blocked
+        const md = '![tracker](</\\evil.example.com/tracker.png>)';
+        await MdTextRender(
+            doc as never,
+            md,
+            createRenderOptions({
+                security: {
+                    enabled: true,
+                    allowedImageDomains: ['good.example.com'],
+                    blockPrivateIPs: true,
+                    blockMetadataIPs: true,
+                    violationMode: 'skip',
+                },
+            }),
+        );
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Direct API path — covers callers that construct ParsedElement trees
+     * programmatically (bypassing MdTextParser) with raw href values that the
+     * pre-fix code would have misclassified as safe relative paths.
+     */
+    it('blocks backslash-obfuscated hrefs when called via prefetchImages directly', async () => {
+        const security = createSecurity({
+            allowedImageDomains: ['good.example.com'],
+            blockPrivateIPs: true,
+            blockMetadataIPs: true,
+            violationMode: 'skip',
+        });
+        const nodes = [
+            { type: 'image', src: '\\\\evil.example.com/steal.png' },  // \\evil.com
+            { type: 'image', src: '/\\evil.example.com/steal.png' },   // /\evil.com
+        ];
+        await prefetchImages(nodes as never, security);
+
+        expect(nodes[0].src).toBeUndefined();
+        expect(nodes[1].src).toBeUndefined();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+});

--- a/test/security/url-classification-bypass.test.ts
+++ b/test/security/url-classification-bypass.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { validateResourceUrl } from '../../src/security/security-policy';
+import { RenderSecurityOptions } from '../../src/types/security';
+
+describe('URL classification bypass (backslash host obfuscation)', () => {
+    const security: RenderSecurityOptions = {
+        enabled: true,
+        allowedImageDomains: ['good.example.com'],
+        allowedLinkProtocols: ['https:', 'http:', 'mailto:', 'tel:'],
+        blockLocalhost: true,
+        blockPrivateIPs: true,
+        blockLinkLocalIPs: true,
+        blockMetadataIPs: true,
+        violationMode: 'skip',
+    };
+
+    // --- Exploit regression tests: these MUST return false ---
+
+    it('rejects a backslash-backslash obfuscated image host', async () => {
+        const allowed = await validateResourceUrl('\\\\evil.example.com/steal.png', 'image', security);
+        expect(allowed).toBe(false);
+    });
+
+    it('rejects a slash-backslash obfuscated image host', async () => {
+        const allowed = await validateResourceUrl('/\\evil.example.com/steal.png', 'image', security);
+        expect(allowed).toBe(false);
+    });
+
+    it('rejects a backslash-obfuscated cloud metadata IP', async () => {
+        const allowed = await validateResourceUrl('\\\\169.254.169.254/latest/meta-data/', 'image', security);
+        expect(allowed).toBe(false);
+    });
+
+    it('rejects a backslash-obfuscated host for links, not just images', async () => {
+        // Use an obfuscated localhost address — this should be blocked because
+        // after normalization \\127.0.0.1/steal → //127.0.0.1/steal → external absolute,
+        // and 127.0.0.1 is blocked by blockLocalhost.
+        const allowed = await validateResourceUrl('\\\\127.0.0.1/steal', 'link', security);
+        expect(allowed).toBe(false);
+    });
+
+    it('rejects a tab-obfuscated javascript: scheme in links (defense in depth)', async () => {
+        const allowed = await validateResourceUrl('java\tscript:alert(1)', 'link', security);
+        expect(allowed).toBe(false);
+    });
+
+    // --- Regression tests: legitimate behavior MUST be unchanged ---
+
+    it('still allows legitimate relative paths', async () => {
+        for (const relative of ['/dashboard', './file.png', '?q=1', '#section']) {
+            expect(await validateResourceUrl(relative, 'link', security)).toBe(true);
+        }
+    });
+
+    it('still allows a protocol-relative URL on an allowed image domain', async () => {
+        const allowed = await validateResourceUrl('//good.example.com/img.png', 'image', security);
+        expect(allowed).toBe(true);
+    });
+
+    it('still blocks a protocol-relative URL on a disallowed image domain', async () => {
+        const allowed = await validateResourceUrl('//evil.example.com/img.png', 'image', security);
+        expect(allowed).toBe(false);
+    });
+
+    it('still allows a normal https link with an allowed protocol', async () => {
+        const allowed = await validateResourceUrl('https://good.example.com/page', 'link', security);
+        expect(allowed).toBe(true);
+    });
+
+    it('still blocks a disallowed protocol on links (e.g. ftp:)', async () => {
+        const allowed = await validateResourceUrl('ftp://good.example.com/file', 'link', security);
+        expect(allowed).toBe(false);
+    });
+});


### PR DESCRIPTION
- normalize URLs before classification to prevent backslash and control-character bypasses
- ensure URL parsing and security validation use the normalized value consistently
- add unconditional pre-parse guards for markdown length and structural nesting limits
- introduce `MarkdownParsingLimitError` for parser safety violations
- wrap markdown parsing errors to avoid uncaught parser exceptions
- export the new parsing error from the public API
- add regression tests for URL classification bypass scenarios
- add parser DoS tests covering nested blockquotes, nested lists, and oversized input
- add end-to-end renderer tests for SSRF bypass prevention
- update README with always-on parser safety limits and new exported error