### PR TITLE
docs: sync documentation with 4.2.0 and add working conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# Working conventions
+
+Conventions for anyone — human or agent — working in this repository.
+
+## Commits
+
+- **Author identity:** commits are authored as the contributor who made them —
+  whatever `git config user.name` / `user.email` resolves to for that person.
+  Never substitute a shared, generic or tooling identity.
+- **No AI attribution.** Do not add `Co-Authored-By: Claude …`, `Claude-Session:`,
+  `Generated with …` or any similar trailer to commit messages. An agent working
+  on someone's behalf commits as that person, with no extra trailers.
+- **Conventional Commits** for the subject: `fix(renderer): …`, `feat(layout): …`,
+  `build:`, `test:`, `docs:`, `ci:`, `chore:`. Scope where it clarifies.
+- Explain what was wrong and what the user-visible effect of the change is, not
+  just which code moved. See `f24cf93` for the house style: a scoped subject
+  followed by a terse bulleted body.
+
+## Branches
+
+- Name the branch after the change, with a conventional prefix:
+  `fix/blockquote-paint-order`, `feat/margin-page-geometry`,
+  `docs/sync-4-2-options`, `ci/node-matrix`.
+- No fixed or session-derived prefixes.
+
+## Releases
+
+- The version bump lives on the default branch and is cut at release time. Feature
+  branches must not touch `version` in `package.json`.
+- Release notes live in GitHub Releases; this repo has no `CHANGELOG.md`.
+- Tags are `vX.Y.Z` and must match `package.json` — `publish.yml` enforces this.
+
+## Testing
+
+Before pushing: `npm run verify` (lint + typecheck + tests). For anything that
+touches packaging, also `bash scripts/smoke-package.sh`.
+
+### The golden snapshot suite
+
+`test/golden` renders markdown fixtures through a real `jsPDF` and snapshots the
+full drawing transcript — every glyph run, rule, box and image, with coordinates.
+It exists because every bug ever filed on this project was a layout bug found by
+a user in production, and nothing asserted where content lands on the page.
+
+**If a change moves anything, a snapshot fails. That is the suite working.**
+Read the diff, confirm every moved coordinate is intended, and only then run
+`npx vitest run golden -u`. Never update snapshots to silence a failure.
+
+Add a fixture to `test/golden/fixtures/` whenever you fix a rendering bug.
+
+## Changes that affect existing users' output
+
+Sort every rendering change into one of two buckets:
+
+- **Output that was already wrong** — content dropped, covered, or printed as raw
+  markup. Fixing it can only improve an existing document. Ships in a minor.
+- **Output that already looked fine** — spacing, line breaking, alignment
+  defaults. Changing it reflows documents people have tuned. Needs an option
+  defaulting to current behaviour, with the correction opt-in.
+
+`spacing.blankLines` and `breaks` are the existing examples of the second kind.
+Their defaults preserve 4.1.x output and are not to be flipped in a minor.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,8 @@ Split rendering changes into two kinds:
   opt-in until the next major.
 
 `spacing.blankLines` and `breaks` are the current examples of the second kind.
-See the deprecation table in `CHANGELOG.md`.
+See the scheduled default changes table in the
+[Options Reference](https://jeelgajera.github.io/jspdf-md-renderer/api/options).
 
 ## Tests
 

--- a/docs-site/api/options.md
+++ b/docs-site/api/options.md
@@ -82,6 +82,41 @@ Spacing precedence:
 - `spacing.betweenListItems` has higher priority.
 - `list.itemSpacing` is used only when `spacing.betweenListItems` is not set.
 
+### Blank Lines Between Blocks
+
+```ts
+spacing: {
+  blankLines: 'preserve', // 'preserve' | 'collapse'
+}
+```
+
+Controls whether blank lines in the Markdown source add vertical space on top of
+the configured `spacing.*` values.
+
+- `'preserve'` (default) — each blank line adds a line of space in addition to
+  the `spacing.*` value. This is the historical behaviour, so existing documents
+  render unchanged.
+- `'collapse'` — blank lines add nothing, so the `spacing.*` options alone
+  determine the gap between blocks. The gap no longer varies with how many blank
+  lines the author happened to leave in the source.
+
+Use `'collapse'` when you want spacing to be fully determined by your
+configuration. See [Scheduled default changes](#scheduled-default-changes).
+
+### Line Breaks
+
+```ts
+breaks: true // top-level option, not nested under `page`
+```
+
+Controls how a single newline inside a paragraph is rendered.
+
+- `true` (default) — renders a hard line break. Historical behaviour.
+- `false` — renders a space, which is what CommonMark specifies for a soft line
+  break.
+
+An explicit `<br>` always breaks the line regardless of this setting.
+
 ### Blockquotes
 
 ```ts
@@ -120,6 +155,29 @@ Tables follow the same content column as other block elements:
 - left margin follows `page.xpading + indent`
 - width is constrained to `page.maxContentWidth - indent`
 
+Column alignment is read from the Markdown delimiter row and applied
+automatically — see [Tables](/elements/tables).
+
+## Scheduled Default Changes
+
+Two options currently default to the behaviour of 4.1.x so that upgrading does
+not move anything on an existing page. Their defaults are scheduled to change in
+a future release. Setting them explicitly makes that upgrade a no-op.
+
+| Option | Current default | Future default | Effect of the future value |
+| --- | --- | --- | --- |
+| `spacing.blankLines` | `'preserve'` | `'collapse'` | Blank lines stop adding vertical space, so `spacing.*` alone decides block gaps |
+| `breaks` | `true` | `false` | A single newline renders as a space rather than a hard break, per CommonMark |
+
+```ts
+// Opt in to the future behaviour today
+const options = {
+  // ...other options
+  spacing: { blankLines: 'collapse' },
+  breaks: false,
+}
+```
+
 ## Security Options (opt-in)
 
 Security is disabled by default for backward compatibility.
@@ -150,8 +208,9 @@ security: {
   maxMarkdownLength: 500_000,
   maxImageCount: 200,
   maxImageSizeBytes: 10 * 1024 * 1024,
-  maxNestedDepth: 20,
+  maxNestedDepth: 20,        // structural containers, not AST levels
   renderTimeoutMs: 30_000,
+  imageFetchTimeoutMs: 10_000, // per remote image request; 0 disables
 
   // Hooks
   validateUrl: async (url, type) => true,
@@ -168,6 +227,28 @@ security: {
 - `skip`: block unsafe item and continue rendering.
 - `throw`: throw `SecurityViolationError` and abort render.
 - `placeholder`: render safe placeholder text instead of blocked content where supported.
+
+### Nesting Depth Semantics
+
+`maxNestedDepth` counts **structural containers** — lists, list items,
+blockquotes and tables. Inline wrappers such as emphasis or links do not count
+towards it, so the value corresponds to Markdown nesting as an author would
+count it.
+
+When the limit is exceeded the nested content is dropped, a
+`MAX_NESTED_DEPTH_EXCEEDED` violation is raised, and the number of dropped nodes
+is reported as a warning so the omission is never silent.
+
+### Remote Image Fetching
+
+`imageFetchTimeoutMs` bounds each individual remote image request. It is separate
+from `renderTimeoutMs`, which is only sampled at checkpoints between render
+phases and therefore cannot interrupt a request to a host that never responds.
+
+Redirects are followed manually rather than transparently: every hop is
+re-validated against the same protocol, domain and SSRF rules as the original
+URL, with the chain bounded to 5 hops. A host that is permitted cannot redirect
+the fetch to one that is not.
 
 ### Domain Allowlist Semantics
 

--- a/docs-site/elements/tables.md
+++ b/docs-site/elements/tables.md
@@ -2,8 +2,9 @@
 title: Tables
 description: How GFM tables are rendered in jspdf-md-renderer.
 llm_summary: |
-  Tables use GFM pipe syntax and are rendered via jspdf-autotable. Table styling can be
-  customized by passing jspdf-autotable UserOptions through the table option in RenderOption.
+  Tables use GFM pipe syntax and are rendered via jspdf-autotable. Column alignment is read
+  from the delimiter row. Table styling can be customized by passing jspdf-autotable
+  UserOptions through the table option in RenderOption.
 ---
 
 # Tables
@@ -23,8 +24,42 @@ GFM (GitHub Flavored Markdown) pipe tables are rendered using [jspdf-autotable](
 
 - Headers are rendered with bold styling
 - Table is automatically sized to fit within `page.maxContentWidth`
-- Cell content is text-only (inline formatting not supported in table cells)
+- Column alignment is taken from the delimiter row (see below)
+- Cell content renders as plain text — inline markup is read and its markers
+  removed, but the styling itself is not applied (see [Cell content](#cell-content))
 - Tables that exceed the page height trigger automatic page breaks
+
+## Column Alignment
+
+Alignment markers in the delimiter row are applied to the whole column,
+header included.
+
+```markdown
+| Left | Center | Right |
+|:-----|:------:|------:|
+| a    | b      | c     |
+```
+
+| Delimiter | Alignment |
+|-----------|-----------|
+| `:---`    | Left |
+| `:---:`   | Center |
+| `---:`    | Right |
+| `---`     | Default (left) |
+
+An explicit `columnStyles` entry in the `table` option overrides the alignment
+parsed from the Markdown.
+
+## Cell Content
+
+Cells render as plain text. Inline markup inside a cell is parsed and its
+markers are stripped, so `**bold**` renders as `bold` rather than showing the
+asterisks — but the emphasis itself is not applied, and a link renders as its
+label without becoming clickable.
+
+This is a limitation of drawing cells through jspdf-autotable, which has no
+concept of mixed inline runs within a cell. Full inline styling inside cells is
+planned.
 
 ## Customizing Table Styles
 

--- a/docs-site/elements/text-styles.md
+++ b/docs-site/elements/text-styles.md
@@ -2,9 +2,9 @@
 title: Text Styles
 description: Bold, italic, and bold-italic text rendering in jspdf-md-renderer.
 llm_summary: |
-  Supports bold (**text** or __text__), italic (*text* or _text_), and bold-italic
-  (***text*** or ___text___). Uses font.bold for bold, font.regular italic for italic.
-  Inline code uses codespan options for styling.
+  Supports bold (**text** or __text__), italic (*text* or _text_), bold-italic
+  (***text*** or ___text___), and GFM strikethrough (~~text~~). Uses font.bold for bold,
+  font.regular italic for italic. Inline code uses codespan options for styling.
 ---
 
 # Text Styles
@@ -17,6 +17,7 @@ jspdf-md-renderer supports inline text formatting within paragraphs and other el
 **Bold text** or __bold text__
 *Italic text* or _italic text_
 ***Bold and italic*** or ___bold and italic___
+~~Strikethrough~~
 `Inline code`
 ```
 
@@ -27,7 +28,12 @@ jspdf-md-renderer supports inline text formatting within paragraphs and other el
 | Bold | `**text**` or `__text__` | `font.bold` |
 | Italic | `*text*` or `_text_` | `font.italic` (falls back to `font.regular` with italic style) |
 | Bold Italic | `***text***` | `font.boldItalic` (falls back to `font.italic` or `font.bold`) |
+| Strikethrough | `~~text~~` | Current font, with a rule drawn across the run |
 | Inline Code | `` `text` `` | Monospace with background |
+
+Strikethrough is drawn manually, because PDF has no text-decoration primitive:
+a rule is stroked across each struck word in the current text colour. It composes
+with the other styles, so `~~**bold**~~` renders bold and struck through.
 
 ## Inline Code Styling
 

--- a/docs-site/guide/security.md
+++ b/docs-site/guide/security.md
@@ -81,6 +81,16 @@ security: {
 
 These checks include IPv4 and IPv6/private-mapped variants.
 
+### Redirects
+
+Remote image fetches follow redirects manually rather than transparently. Every
+hop is re-validated against the same protocol, domain and SSRF rules as the
+original URL, and the chain is bounded to 5 hops.
+
+This matters because a permitted host would otherwise be able to redirect the
+request to an address the policy forbids: validating only the URL the Markdown
+supplied is not enough when the fetch itself follows the redirect.
+
 ## Limit Controls (DoS)
 
 ```ts
@@ -91,12 +101,23 @@ security: {
   maxImageSizeBytes: 10 * 1024 * 1024,
   maxNestedDepth: 20,
   renderTimeoutMs: 30_000,
+  imageFetchTimeoutMs: 10_000,
 }
 ```
 
 Notes:
 - `maxImageSizeBytes` for data URLs uses decoded payload bytes.
 - depth/image-count limits sanitize the parsed tree before rendering.
+- `maxNestedDepth` counts **structural containers** — lists, list items,
+  blockquotes and tables. Inline wrappers such as emphasis and links do not
+  count, so the value matches Markdown nesting as an author would count it.
+  Exceeding it drops the nested content, raises a
+  `MAX_NESTED_DEPTH_EXCEEDED` violation, and reports how many nodes were
+  dropped, so the omission is never silent.
+- `imageFetchTimeoutMs` bounds each individual remote image request; `0`
+  disables it. It is separate from `renderTimeoutMs`, which is only sampled at
+  checkpoints between render phases and so cannot interrupt a request to a host
+  that never responds.
 
 ## Custom Hook Controls
 
@@ -140,5 +161,6 @@ security: {
   maxImageSizeBytes: 10 * 1024 * 1024,
   maxNestedDepth: 20,
   renderTimeoutMs: 30_000,
+  imageFetchTimeoutMs: 10_000,
 }
 ```

--- a/docs-site/public/llms.txt
+++ b/docs-site/public/llms.txt
@@ -86,12 +86,15 @@ Parses markdown into structured tokens.
 - bold (**text** or __text__)
 - italic (*text* or _text_)
 - bold-italic (***text***)
+- strikethrough (~~text~~)
+- escaped characters (\*, \_)
 - code blocks (fenced ```lang blocks)
 - inline code (`code`)
 - links ([text](url))
 - blockquotes (> text)
 - images (![alt](url) with optional attributes)
-- tables (GFM pipe tables)
+- tables (GFM pipe tables, with column alignment from the delimiter row)
+- reference links ([text][ref] with [ref]: url definitions)
 
 ## Image Attribute Syntax
 ```


### PR DESCRIPTION
Three options shipped in 4.2.0 were missing from the documentation site, and two published pages described behaviour the release had changed.

### Corrections

- **`maxNestedDepth`** — both the options reference and the security guide still described it as counting AST levels. It counts structural containers, which roughly doubles the usable nesting depth compared to what the pages implied.
- **Redirects** — remote image fetches now revalidate every hop. Previously undocumented.
- **Table cells** — the page said inline formatting was unsupported. It's read and its markers stripped; the styling isn't applied. Now says so precisely.

### Additions

- `spacing.blankLines` and `breaks`, plus a **Scheduled Default Changes** table so readers know both defaults are set to flip and how to opt in early
- `security.imageFetchTimeoutMs`, and why it's separate from `renderTimeoutMs`
- Table column alignment from the delimiter row
- **Strikethrough** — shipped in 4.2.0 and was absent from the text styles page entirely
- `llms.txt` refreshed: strikethrough, escaped characters, reference links, column alignment

### Also

- `CONTRIBUTING.md` repointed at the Options Reference, replacing a link to the deleted `CHANGELOG.md`
- `CLAUDE.md` recording commit, branch, release, testing and golden-snapshot conventions

Verified by building the docs site, which resolves internal links at build time. Repo checks green: lint, typecheck, 143 tests.